### PR TITLE
Changed DisplayName Binding Mode to OneWay to avoid crash.

### DIFF
--- a/WPFUI/CharacterCreation.xaml
+++ b/WPFUI/CharacterCreation.xaml
@@ -61,7 +61,7 @@
 
             <DataGrid.Columns>
                 <DataGridTextColumn Header="Attribute"
-                                    Binding="{Binding DisplayName}"
+                                    Binding="{Binding DisplayName, Mode=OneWay}"
                                     Width="*"/>
                 <DataGridTextColumn Header="Value"
                                     Binding="{Binding BaseValue}"/>


### PR DESCRIPTION
- On Character Creation screen, double clicking the attribute column of any row leads to a crash.